### PR TITLE
adding protocol, keypath, and certpath as options to serve

### DIFF
--- a/bin/api-console-serve.js
+++ b/bin/api-console-serve.js
@@ -25,6 +25,9 @@ program
   .option('-o, --open', docs.open)
   .option('-b, --browser [value]', docs.browser, collect, [])
   .option('-l, --open-path [value]', docs.openPath)
+  .option('-P, --protocol [value]', docs.protocol)
+  .option('-k, --key-path [value]', docs.keyPath)
+  .option('-c, --cert-path [value]', docs.certPath)
   .on('--help', function() {
     console.log('\n\n  Examples:');
     console.log();
@@ -32,6 +35,7 @@ program
     console.log('    $ api-console serve build/');
     console.log('    $ api-console serve --open');
     console.log('    $ api-console serve -H 192.168.1.10 -p 8081');
+    console.log('    $ api-console serve -H mytest.local -p 8081 -P https -k ./path/to/key -c ./path/to/cert');
     console.log();
   })
   .parse(process.argv);

--- a/bin/serve-help.json
+++ b/bin/serve-help.json
@@ -7,5 +7,8 @@
   "headers": "Headers to send with every response.",
   "open": "Whether to open the browser when run",
   "browser": "The browser(s) to open when run with open argument.",
-  "openPath": "The URL path to open in each browser"
+  "openPath": "The URL path to open in each browser",
+  "protocol": "The protocol, choice of [http, https], defaults to http",
+  "keyPath": "The file path to ssl key",
+  "certPath": "The file path to ssl cert"
 }

--- a/docs/api-console-serve.md
+++ b/docs/api-console-serve.md
@@ -74,3 +74,21 @@ The browser(s) to open when run with open argument.
 Type: `String`
 
 The URL path to open in each browser
+
+#### `-P, --protocol [value]`
+
+Type: `String`
+
+The protocol, choice of [http, https], defaults to http
+
+#### `-k, --keyPath [value]`
+
+Type: `String`
+
+The file path to ssl key
+
+#### `-c, --certPath [value]`
+
+Type: `String`
+
+jThe file path to ssl cert

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -23,6 +23,9 @@ class ApiServe extends ApiBase {
       root = options.args[0];
     }
     var opts = {};
+    // Set protocol as http by default
+    opts.protocol = 'http';
+
     if (root) {
       opts.root = root;
     }
@@ -43,6 +46,17 @@ class ApiServe extends ApiBase {
     }
     if (options.openPath) {
       opts.openPath = options.openPath;
+    }
+    if (options.protocol) {
+      var possibleProtocols = ['http', 'https'];
+      opts.protocol = ~possibleProtocols.indexOf(options.protocol) ?
+        options.protocol : 'http';
+    }
+    if (options.keyPath) {
+      opts.keyPath = options.keyPath;
+    }
+    if (options.certPath) {
+      opts.certPath = options.certPath;
     }
     return opts;
   }

--- a/test/serve.test.js
+++ b/test/serve.test.js
@@ -42,6 +42,19 @@ describe('api-console-cli', () => {
         var serve = new ApiServe(opts);
         assert.deepEqual(serve.opts.browser, ['test']);
       });
+
+      it(`Sets protocol from option argument`, function() {
+        var opts = {
+          protocol: 'https'
+        };
+        var serve = new ApiServe(opts);
+        assert.deepEqual(serve.opts.protocol, 'https');
+      });
+
+      it(`Sets protocol to http by default`, function() {
+        var serve = new ApiServe({});
+        assert.deepEqual(serve.opts.protocol, 'http');
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds more options acceptable by `polyserve` specifically for the ability to serve via https:
- `protocol`
- `keyPath`
- `certPath`

Look forward to your feedback.  Thanks.

Richard