### PR TITLE
bin/run.js: fix typo

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -15,7 +15,7 @@ program
   .command('generate-json <raml>',
     'Generates a JSON file from RAML spec that is used in the API console')
   .command('serve [path]',
-    'Creates a www server do run the console locally')
+    'Creates a www server to run the console locally')
   .command('dev <raml>',
     'Displays API console while working on RAML sources')
   .parse(process.argv);


### PR DESCRIPTION
Fix a trivial typo "do" -> "to".